### PR TITLE
Files with multiple extensions don't get the correct icon

### DIFF
--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -48,13 +48,12 @@ M.get_node = function(line)
 		}
 	end
 
-	local ext
-	ext = function(file)
-		local extensionStart = file:find('.', 0, true)
+	local function ext(file)
+		local extensionStart = file:find(".", 0, true)
 
-		if (extensionStart == nil) then
+		if extensionStart == nil then
 			return nil
-		elseif (extensionStart == 1) then
+		elseif extensionStart == 1 then
 			return ext(file:sub(2))
 		end
 

--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -48,7 +48,8 @@ M.get_node = function(line)
 		}
 	end
 
-	local ext = function(file)
+	local ext
+	ext = function(file)
 		local extensionStart = file:find('.', 0, true)
 
 		if (extensionStart == nil) then

--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -9,65 +9,65 @@ M.TYPE_SYMLINK = 2
 ---@param line string
 ---@return Word|nil
 M.get_node = function(line)
-    if string.find(line, '^"') then
-        return nil
-    end
+        if string.find(line, '^"') then
+                return nil
+        end
 
-    -- When netrw is empty, there's one line in the buffer and it is empty.
-    if line == "" then
-        return nil
-    end
+        -- When netrw is empty, there's one line in the buffer and it is empty.
+        if line == "" then
+                return nil
+        end
 
-    local curdir = vim.b.netrw_curdir
+        local curdir = vim.b.netrw_curdir
 
-    local _, _, node, link = string.find(line, "^(.+)@\t%s*%-%->%s*(.+)")
-    if node then
+        local _, _, node, link = string.find(line, "^(.+)@\t%s*%-%->%s*(.+)")
+        if node then
+                return {
+                        dir = curdir,
+                        node = node,
+                        link = link,
+                        type = M.TYPE_SYMLINK,
+                }
+        end
+
+        local _, _, node_2 = string.find(line, "^([^%s]+)@%s*")
+        if node_2 then
+                return {
+                        dir = curdir,
+                        node = node_2,
+                        type = M.TYPE_SYMLINK,
+                }
+        end
+
+        local _, _, dir = string.find(line, "^([^%s]+)/")
+        if dir then
+                return {
+                        dir = curdir,
+                        node = dir,
+                        type = M.TYPE_DIR,
+                }
+        end
+
+        local ext = function(file)
+                local extensionStart = file:find('.', 0, true)
+
+                if (extensionStart == nil) then
+                        return nil
+                elseif (extensionStart == 1) then
+                        return ext(file:sub(2))
+                end
+
+                local extension = file:sub(extensionStart + 1)
+                return extension
+        end
+
+        local _, _, file = string.find(line, "^([^%s^%*]+)[%*]*[%s]*")
         return {
-            dir = curdir,
-            node = node,
-            link = link,
-            type = M.TYPE_SYMLINK,
+                dir = curdir,
+                node = file,
+                extension = ext(file),
+                type = M.TYPE_FILE,
         }
-    end
-
-    local _, _, node_2 = string.find(line, "^([^%s]+)@%s*")
-    if node_2 then
-        return {
-            dir = curdir,
-            node = node_2,
-            type = M.TYPE_SYMLINK,
-        }
-    end
-
-    local _, _, dir = string.find(line, "^([^%s]+)/")
-    if dir then
-        return {
-            dir = curdir,
-            node = dir,
-            type = M.TYPE_DIR,
-        }
-    end
-
-    local ext = function(file)
-        local extensionStart = file:find('.', 0, true)
-
-        if (extensionStart == nil) then
-            return nil
-		elseif (extensionStart == 1) then
-			return ext(file:sub(2))
-		end
-
-        local extension = file:sub(extensionStart + 1)
-        return extension
-    end
-
-    local _, _, file = string.find(line, "^([^%s^%*]+)[%*]*[%s]*")
-    return {
-        dir = curdir,
-        node = file,
-        extension = ext(file),
-        type = M.TYPE_FILE,
-    }
 end
 
 return M

--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -9,51 +9,63 @@ M.TYPE_SYMLINK = 2
 ---@param line string
 ---@return Word|nil
 M.get_node = function(line)
-	if string.find(line, '^"') then
-		return nil
-	end
+    if string.find(line, '^"') then
+        return nil
+    end
 
-	-- When netrw is empty, there's one line in the buffer and it is empty.
-	if line == "" then
-		return nil
-	end
+    -- When netrw is empty, there's one line in the buffer and it is empty.
+    if line == "" then
+        return nil
+    end
 
-	local curdir = vim.b.netrw_curdir
+    local curdir = vim.b.netrw_curdir
 
-	local _, _, node, link = string.find(line, "^(.+)@\t%s*%-%->%s*(.+)")
-	if node then
-		return {
-			dir = curdir,
-			node = node,
-			link = link,
-			type = M.TYPE_SYMLINK,
-		}
-	end
+    local _, _, node, link = string.find(line, "^(.+)@\t%s*%-%->%s*(.+)")
+    if node then
+        return {
+            dir = curdir,
+            node = node,
+            link = link,
+            type = M.TYPE_SYMLINK,
+        }
+    end
 
-	local _, _, node_2 = string.find(line, "^([^%s]+)@%s*")
-	if node_2 then
-		return {
-			dir = curdir,
-			node = node_2,
-			type = M.TYPE_SYMLINK,
-		}
-	end
+    local _, _, node_2 = string.find(line, "^([^%s]+)@%s*")
+    if node_2 then
+        return {
+            dir = curdir,
+            node = node_2,
+            type = M.TYPE_SYMLINK,
+        }
+    end
 
-	local _, _, dir = string.find(line, "^([^%s]+)/")
-	if dir then
-		return {
-			dir = curdir,
-			node = dir,
-			type = M.TYPE_DIR,
-		}
-	end
+    local _, _, dir = string.find(line, "^([^%s]+)/")
+    if dir then
+        return {
+            dir = curdir,
+            node = dir,
+            type = M.TYPE_DIR,
+        }
+    end
 
-	local _, _, file = string.find(line, "^([^%s^%*]+)[%*]*[%s]*")
-	return {
-		dir = curdir,
-		node = file,
-		type = M.TYPE_FILE,
-	}
+    local ext = function(file)
+        local extensionStart = file:find('.', 0, true)
+
+        if (extensionStart == nil) then
+            return nil
+        end
+
+        local extension = file:sub(extensionStart + 1)
+        return extension
+    end
+
+    local _, _, file = string.find(line, "^([^%s^%*]+)[%*]*[%s]*")
+    return {
+        dir = curdir,
+        node = file,
+        extension = ext(file),
+        type = M.TYPE_FILE,
+    }
 end
 
 return M

--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -52,7 +52,6 @@ M.get_node = function(line)
 	return {
 		dir = curdir,
 		node = file,
-		extension = vim.fn.fnamemodify(file, ":e"),
 		type = M.TYPE_FILE,
 	}
 end

--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -53,7 +53,9 @@ M.get_node = function(line)
 
         if (extensionStart == nil) then
             return nil
-        end
+		elseif (extensionStart == 1) then
+			return ext(file:sub(2))
+		end
 
         local extension = file:sub(extensionStart + 1)
         return extension

--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -9,65 +9,65 @@ M.TYPE_SYMLINK = 2
 ---@param line string
 ---@return Word|nil
 M.get_node = function(line)
-        if string.find(line, '^"') then
-                return nil
-        end
+	if string.find(line, '^"') then
+		return nil
+	end
 
-        -- When netrw is empty, there's one line in the buffer and it is empty.
-        if line == "" then
-                return nil
-        end
+	-- When netrw is empty, there's one line in the buffer and it is empty.
+	if line == "" then
+		return nil
+	end
 
-        local curdir = vim.b.netrw_curdir
+	local curdir = vim.b.netrw_curdir
 
-        local _, _, node, link = string.find(line, "^(.+)@\t%s*%-%->%s*(.+)")
-        if node then
-                return {
-                        dir = curdir,
-                        node = node,
-                        link = link,
-                        type = M.TYPE_SYMLINK,
-                }
-        end
+	local _, _, node, link = string.find(line, "^(.+)@\t%s*%-%->%s*(.+)")
+	if node then
+		return {
+			dir = curdir,
+			node = node,
+			link = link,
+			type = M.TYPE_SYMLINK,
+		}
+	end
 
-        local _, _, node_2 = string.find(line, "^([^%s]+)@%s*")
-        if node_2 then
-                return {
-                        dir = curdir,
-                        node = node_2,
-                        type = M.TYPE_SYMLINK,
-                }
-        end
+	local _, _, node_2 = string.find(line, "^([^%s]+)@%s*")
+	if node_2 then
+		return {
+			dir = curdir,
+			node = node_2,
+			type = M.TYPE_SYMLINK,
+		}
+	end
 
-        local _, _, dir = string.find(line, "^([^%s]+)/")
-        if dir then
-                return {
-                        dir = curdir,
-                        node = dir,
-                        type = M.TYPE_DIR,
-                }
-        end
+	local _, _, dir = string.find(line, "^([^%s]+)/")
+	if dir then
+		return {
+			dir = curdir,
+			node = dir,
+			type = M.TYPE_DIR,
+		}
+	end
 
-        local ext = function(file)
-                local extensionStart = file:find('.', 0, true)
+	local ext = function(file)
+		local extensionStart = file:find('.', 0, true)
 
-                if (extensionStart == nil) then
-                        return nil
-                elseif (extensionStart == 1) then
-                        return ext(file:sub(2))
-                end
+		if (extensionStart == nil) then
+			return nil
+		elseif (extensionStart == 1) then
+			return ext(file:sub(2))
+		end
 
-                local extension = file:sub(extensionStart + 1)
-                return extension
-        end
+		local extension = file:sub(extensionStart + 1)
+		return extension
+	end
 
-        local _, _, file = string.find(line, "^([^%s^%*]+)[%*]*[%s]*")
-        return {
-                dir = curdir,
-                node = file,
-                extension = ext(file),
-                type = M.TYPE_FILE,
-        }
+	local _, _, file = string.find(line, "^([^%s^%*]+)[%*]*[%s]*")
+	return {
+		dir = curdir,
+		node = file,
+		extension = ext(file),
+		type = M.TYPE_FILE,
+	}
 end
 
 return M

--- a/lua/netrw/ui.lua
+++ b/lua/netrw/ui.lua
@@ -25,7 +25,7 @@ M.embelish = function(bufnr)
 				if has_devicons then
 					local ic, color = devicons.get_icon_color(word.node)
 					if ic then
-						local hl_group = "FileIconColor" .. word.node
+						local hl_group = "FileIconColor" .. word.node::gsub("[- %%]", "")
 						vim.api.nvim_set_hl(0, hl_group, { fg = color })
 						opts.sign_hl_group = hl_group
 						opts.sign_text = ic

--- a/lua/netrw/ui.lua
+++ b/lua/netrw/ui.lua
@@ -23,11 +23,11 @@ M.embelish = function(bufnr)
 			if config.options.use_devicons then
 				local has_devicons, devicons = pcall(require, "nvim-web-devicons")
 				if has_devicons then
-					local ic, color = devicons.get_icon_color(word.node, word.extension)
+					local ic, color = devicons.get_icon_color(word.node)
 					if ic then
-						local hl_group = "FileIconColor" .. word.extension
+						local hl_group = "FileIconColor" .. word.node
 						vim.api.nvim_set_hl(0, hl_group, { fg = color })
-						opts.sign_hl_group = "FileIconColor" .. word.extension
+						opts.sign_hl_group = hl_group
 						opts.sign_text = ic
 					end
 				end

--- a/lua/netrw/ui.lua
+++ b/lua/netrw/ui.lua
@@ -25,7 +25,7 @@ M.embelish = function(bufnr)
 				if has_devicons then
 					local ic, color = devicons.get_icon_color(word.node)
 					if ic then
-						local hl_group = "FileIconColor" .. word.node::gsub("[- %%]", "")
+						local hl_group = "FileIconColor" .. word.node:gsub("[- %%]", "")
 						vim.api.nvim_set_hl(0, hl_group, { fg = color })
 						opts.sign_hl_group = hl_group
 						opts.sign_text = ic


### PR DESCRIPTION
Files with extensions like `.test.ts` don't get the correct icon, because only one extension is returned by the `fnamemodify` call on line 55 of the `parse.lua` file.

While a good solution to this might seem to be adding more `:e` modifiers, the way looking up a file by extension works, a file with multiple extensions without a supported icon (maybe something like `.config.ts`, where to correct icon would be the ts one) doesn't get an icon.

Looking into nvim-web-devicons, I found that `devicons.get_icon_color` internally iterates over the filename to get the longest extension that has an icon, but only does this when the extension is not specified ([link to the source](https://github.com/nvim-tree/nvim-web-devicons/blob/986875b7364095d6535e28bd4aac3a9357e91bbe/lua/nvim-web-devicons.lua#LL1943C1-L1952C4)).

This PR removes the need for processing the extension, and leaves that entirely to the `devicons` extension.