### PR TITLE
fix: icons highlighting and complex extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ require'netrw'.setup{
   icons = {
     symlink = '', -- Symlink icon (directory and file)
     directory = '', -- Directory icon
-    file = '', -- File icon
+    file = '', -- File icon
   },
   use_devicons = true, -- Uses nvim-web-devicons if true, otherwise use the file icon specified above
   mappings = {}, -- Custom key mappings

--- a/doc/netrw.nvim.txt
+++ b/doc/netrw.nvim.txt
@@ -33,7 +33,7 @@ Enable the plugin: >
     icons = {
       symlink = '', -- Symlink icon (directory and file)
       directory = '', -- Directory icon
-      file = '', -- File icon
+      file = '', -- File icon
     },
     use_devicons = true, -- Uses nvim-web-devicons if true, otherwise use the file icon specified above
     mappings = {}, -- Custom key mappings

--- a/lua/netrw/config.lua
+++ b/lua/netrw/config.lua
@@ -5,7 +5,7 @@ local defaults = {
 	icons = {
 		symlink = "",
 		directory = "",
-		file = "",
+		file = "",
 	},
 	use_devicons = true,
 	mappings = {},

--- a/lua/netrw/ui.lua
+++ b/lua/netrw/ui.lua
@@ -23,11 +23,9 @@ M.embelish = function(bufnr)
 			if config.options.use_devicons then
 				local has_devicons, devicons = pcall(require, "nvim-web-devicons")
 				if has_devicons then
-					local ic, color = devicons.get_icon_color(word.node, word.extension)
+					local ic, hi = devicons.get_icon(word.node, nil, { strict = true, default = false })
 					if ic then
-						local hl_group = "FileIconColor" .. word.extension
-						vim.api.nvim_set_hl(0, hl_group, { fg = color })
-						opts.sign_hl_group = "FileIconColor" .. word.extension
+						opts.sign_hl_group = hi
 						opts.sign_text = ic
 					end
 				end


### PR DESCRIPTION
Make better use of the nvim-web-devicon package, allowing the parsing of complex extensions (e.g. `*.test.js`, `Dockerfile`, etc.)

Also, change default file icon following deprecation of some glyphs.

Resolves in a simpler way what was raised here: https://github.com/prichrd/netrw.nvim/pull/22