### PR TITLE
fix(#26): set signcolumn to `yes` for netrw buffers

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,10 +1,10 @@
 stds.nvim = {
-  read_globals = {
+  globals = {
     "vim",
   },
 }
 std = "lua51+nvim"
 
 include_files = {
-    "lua/**/*.lua",
+  "lua/**/*.lua",
 }

--- a/lua/netrw/config.lua
+++ b/lua/netrw/config.lua
@@ -30,6 +30,9 @@ function M.setup(options)
 				return
 			end
 
+			-- Forces the usage of signcolumn in netrw buffers.
+			vim.opt_local.signcolumn = "yes"
+
 			local bufnr = vim.api.nvim_get_current_buf()
 			require("netrw.ui").embelish(bufnr)
 			require("netrw.actions").bind(bufnr)


### PR DESCRIPTION
Some users may want to disable the signcolumn globally, and still use the netrw plugin. This change sets the signcolumn value to `yes` locally.

Fixes #26. Thank you @shesmu for raising the issue and suggesting to make it part of the plugin :)