### PR TITLE
Custom file icon addition options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ require'netrw'.setup{
 
 * First you have to locate your nvim-data files to go and alter the lua code that runs the extention.
 
+Type:
+
 ```
 :echo $VIM -- Will output where vim looks for vimfiles.
 
@@ -106,13 +108,13 @@ You're going to want to edit:
 Where you:
 
 * Add
-```
+```lua
 M.TYPE_{file type in capitals} = {index}
 ```
 In the relevant block at the top of the file.
 
 * Add
-```
+```lua
     local _, _, {file type} = string.find(line, "^(.*)%.{extention}")
     if {file type} then
         return {
@@ -125,7 +127,7 @@ In the relevant block at the top of the file.
 
 ```
 ### Example:
-```
+```lua
   local _, _, markdown = string.find(line, "^(.*)%.md")
   if markdown then
       return {
@@ -154,7 +156,7 @@ Where you:
 {alias} = "{symbol}"
 ```
 In the relevant block at the top of the file.
-```
+```lua
   {
     ---@class Config
     local defaults = {
@@ -184,12 +186,12 @@ In the relevant block at the top of the file.
 Where you:
 
 * Add
-```
+```lua
   elseif node.type == parse.TYPE_{file type in capitals} then
     icon = config.options.icond.{alias}
 ```
 ### Example
-```
+```lua
   elseif node.type == parse.TYPE_DIR then
       icon = config.options.icons.directory
   elseif node.type == parse.TYPE_SYMLINK then

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ a layer of *✨bling✨* and configuration to your favorite file explorer.
 
 ## Features
 
-- Print file icons in the sign column
-- Configure custom actions with keybinds
+This plugins adds features to the plain netrw file explorer:
+- Print file icons
+- Configure custom actions via keybinds
 
 ## Requirements
 
@@ -22,17 +23,15 @@ a layer of *✨bling✨* and configuration to your favorite file explorer.
 
 Install the plugin with your preferred package manager:
 
-[vim-plug](https://github.com/junegunn/vim-plug)
+<details>
+<summary><a href="https://github.com/folke/lazy.nvim">Lazy</a></summary>
+<code>{ 'prichrd/netrw.nvim', opts = {} }</code>
+</details>
 
-```vim
-Plug 'prichrd/netrw.nvim'
-```
-
-[packer](https://github.com/wbthomason/packer.nvim)
-
-```lua
-use 'prichrd/netrw.nvim'
-```
+<details>
+<summary><a href="https://github.com/junegunn/vim-plug">vim-plug</a></summary>
+<code>Plug 'prichrd/netrw.nvim'</code>
+</details>
 
 ## Usage
 
@@ -79,6 +78,133 @@ require'netrw'.setup{
   -- your config ...
 }
 ```
+
+## How to add your own symbols
+
+* First you have to locate your nvim-data files to go and alter the lua code that runs the extention.
+
+```
+:echo $VIM -- Will output where vim looks for vimfiles.
+
+:echo $VIMRUNTIME -- Will output vim's runtime path.
+```
+
+You should also look in ```~AppData/Local/nvim-data```.
+
+***
+
+* Once you've found the files. (indicative file paths)
+
+You're going to want to edit:
+
+```
+~\AppData\Local\nvim-data\lazy\netrw.nvim\lua\netrw\parse.lua
+```
+
+***
+
+Where you:
+
+* Add
+```
+M.TYPE_{file type in capitals} = {index}
+```
+In the relevant block at the top of the file.
+
+* Add
+```
+    local _, _, {file type} = string.find(line, "^(.*)%.{extention}")
+    if {file type} then
+        return {
+            dir = curdir,
+            col = 0,
+            node = {file type},
+            type = M.TYPE_{file type in capitals},
+        }
+    end
+
+```
+### Example:
+```
+  local _, _, markdown = string.find(line, "^(.*)%.md")
+  if markdown then
+      return {
+          dir = curdir,
+          col = 0,
+          node = markdown,
+          type = M.TYPE_MARKDOWNFILE,
+      }
+  end
+
+```
+To all 3 functions {parse_liststyle_0, parse_liststyle_1, parse_liststyle_3}.
+
+***
+
+```
+~\AppData\Local\nvim-data\lazy\netrw.nvim\lua\netrw\config.lua
+```
+
+***
+
+Where you:
+
+* Add
+```
+{alias} = "{symbol}"
+```
+In the relevant block at the top of the file.
+```
+  {
+    ---@class Config
+    local defaults = {
+        icons = {
+            symlink = "",
+            directory = "",
+            file = "",
+            -- Examples
+            pdf = "",
+            md = "󰰏",
+            text = "󰊄"
+        },
+        use_devicons = true,
+        mappings = {},
+      }
+  }
+```
+
+***
+
+```
+~\AppData\Local\nvim-data\lazy\netrw.nvim\lua\netrw\ui.lua
+```
+
+***
+
+Where you:
+
+* Add
+```
+  elseif node.type == parse.TYPE_{file type in capitals} then
+    icon = config.options.icond.{alias}
+```
+### Example
+```
+  elseif node.type == parse.TYPE_DIR then
+      icon = config.options.icons.directory
+  elseif node.type == parse.TYPE_SYMLINK then
+      icon = config.options.icons.symlink
+  -- Examples
+  elseif node.type == parse.TYPE_MARKDOWNFILE then
+      icon = config.options.icons.md
+  elseif node.type == parse.TYPE_PDF then
+      icon = config.options.icons.pdf
+  elseif node.type == parse.TYPE_TXT then
+      icon = config.options.icons.text
+  end
+```
+
+***
 
 The plugin documentation can be found at [doc/netrw.nvim.txt](doc/netrw.nvim.txt).
 You can also use the :help netrw.nvim command inside of Neovim.

--- a/lua/netrw/config.lua
+++ b/lua/netrw/config.lua
@@ -3,9 +3,12 @@ local M = {}
 ---@class Config
 local defaults = {
 	icons = {
-		symlink = "",
-		directory = "",
-		file = "",
+		symlink = "",
+		directory = "",
+		file = "",
+		pdf = "",
+		md = "󰰏",
+		text = "󰊄"
 	},
 	use_devicons = true,
 	mappings = {},
@@ -35,7 +38,6 @@ function M.setup(options)
 
 			local bufnr = vim.api.nvim_get_current_buf()
 			require("netrw.ui").embelish(bufnr)
-			require("netrw.actions").bind(bufnr)
 		end,
 		group = vim.api.nvim_create_augroup("netrw", { clear = false }),
 	})

--- a/lua/netrw/parse.lua
+++ b/lua/netrw/parse.lua
@@ -3,6 +3,9 @@ local M = {}
 M.TYPE_DIR = 0
 M.TYPE_FILE = 1
 M.TYPE_SYMLINK = 2
+M.TYPE_MARKDOWNFILE = 3
+M.TYPE_PDF = 4
+M.TYPE_TXT = 5
 
 ---@alias Word {dir:string, node:string, link:string|nil, extension:string|nil, type:number, col:number}
 
@@ -19,6 +22,36 @@ local parse_liststyle_0 = function(line, curdir)
 			extension = vim.fn.fnamemodify(node, ":e"),
 			link = link,
 			type = M.TYPE_SYMLINK,
+		}
+	end
+
+	local _, _, markdown = string.find(line, "^(.*)%.md")
+	if markdown then
+		return {
+			dir = curdir,
+			col = 0,
+			node = markdown,
+			type = M.TYPE_MARKDOWNFILE,
+		}
+	end
+
+	local _, _, pdf = string.find(line, "^(.*)%.pdf")
+	if pdf then
+		return {
+			dir = curdir,
+			col = 0,
+			node = pdf,
+			type = M.TYPE_PDF,
+		}
+	end
+
+	local _, _, txt = string.find(line, "^(.*)%.txt")
+	if txt then
+		return {
+			dir = curdir,
+			col = 0,
+			node = txt,
+			type = M.TYPE_TXT,
 		}
 	end
 
@@ -63,6 +96,36 @@ local parse_liststyle_1 = function(line, curdir)
 		}
 	end
 
+	local _, _, markdown = string.find(line, "^(.*)%.md")
+	if markdown then
+		return {
+			dir = curdir,
+			col = 0,
+			node = markdown,
+			type = M.TYPE_MARKDOWNFILE,
+		}
+	end
+
+	local _, _, pdf = string.find(line, "^(.*)%.pdf")
+	if pdf then
+		return {
+			dir = curdir,
+			col = 0,
+			node = pdf,
+			type = M.TYPE_PDF,
+		}
+	end
+
+	local _, _, txt = string.find(line, "^(.*)%.txt")
+	if txt then
+		return {
+			dir = curdir,
+			col = 0,
+			node = txt,
+			type = M.TYPE_TXT,
+		}
+	end
+
 	local _, _, dir = string.find(line, "^(.*)/")
 	if dir then
 		return {
@@ -90,9 +153,9 @@ local parse_liststyle_1 = function(line, curdir)
 end
 
 ---@param line string
+---@param curdir string
 ---@return Word|nil
-local parse_liststyle_3 = function(line)
-	local curdir = vim.b.netrw_curdir
+local parse_liststyle_3 = function(line, curdir)
 	local _, to = string.find(line, "^[|%s]*")
 	local pipelessLine = string.sub(line, to + 1, #line)
 
@@ -109,6 +172,36 @@ local parse_liststyle_3 = function(line)
 			extension = vim.fn.fnamemodify(node, ":e"),
 			link = link,
 			type = M.TYPE_SYMLINK,
+		}
+	end
+
+	local _, _, markdown = string.find(line, "^(.*)%.md")
+	if markdown then
+		return {
+			dir = curdir,
+			col = 0,
+			node = markdown,
+			type = M.TYPE_MARKDOWNFILE,
+		}
+	end
+
+	local _, _, pdf = string.find(line, "^(.*)%.pdf")
+	if pdf then
+		return {
+			dir = curdir,
+			col = 0,
+			node = pdf,
+			type = M.TYPE_PDF,
+		}
+	end
+
+	local _, _, txt = string.find(line, "^(.*)%.txt")
+	if txt then
+		return {
+			dir = curdir,
+			col = 0,
+			node = txt,
+			type = M.TYPE_TXT,
 		}
 	end
 

--- a/lua/netrw/ui.lua
+++ b/lua/netrw/ui.lua
@@ -23,6 +23,12 @@ local get_icon = function(node)
 		icon = config.options.icons.directory
 	elseif node.type == parse.TYPE_SYMLINK then
 		icon = config.options.icons.symlink
+	elseif node.type == parse.TYPE_MARKDOWNFILE then
+		icon = config.options.icons.md
+	elseif node.type == parse.TYPE_PDF then
+		icon = config.options.icons.pdf
+	elseif node.type == parse.TYPE_TXT then
+		icon = config.options.icons.text
 	end
 
 	return { icon, hl_group }

--- a/test/spec/netrw/parse_spec.lua
+++ b/test/spec/netrw/parse_spec.lua
@@ -13,7 +13,7 @@ local testcases = {
 			col = 0,
 			node = "hello.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{
@@ -35,7 +35,18 @@ local testcases = {
 			col = 0,
 			node = "README.md",
 			extension = "md",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_MARKDOWNFILE,
+		},
+	},
+	{
+		liststyle = 0,
+		line = "quiz.pdf",
+		expected = {
+			dir = curdir,
+			col = 0,
+			node = "quiz.pdf",
+			extension = "pdf",
+			type = parse.TYPE_PDF,
 		},
 	},
 	{
@@ -68,7 +79,7 @@ local testcases = {
 			col = 0,
 			node = "there are spaces.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{
@@ -124,7 +135,6 @@ local testcases = {
 			type = parse.TYPE_FILE,
 		},
 	},
-
 	--
 	-- liststyle 1
 	--
@@ -168,7 +178,7 @@ local testcases = {
 			col = 0,
 			node = "README.md",
 			extension = "md",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_MARKDOWNFILE,
 		},
 	},
 	{
@@ -190,7 +200,7 @@ local testcases = {
 			col = 0,
 			node = "hello2.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{
@@ -201,7 +211,7 @@ local testcases = {
 			col = 0,
 			node = "there are 2 spaces.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{
@@ -236,7 +246,6 @@ local testcases = {
 			},
 		},
 	},
-
 	--
 	-- liststyle 3
 	--
@@ -248,7 +257,7 @@ local testcases = {
 			col = 0,
 			node = "hello.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{
@@ -259,7 +268,7 @@ local testcases = {
 			col = 4,
 			node = "hello.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{
@@ -292,7 +301,7 @@ local testcases = {
 			col = 0,
 			node = "README.md",
 			extension = "md",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_MARKDOWNFILE,
 		},
 	},
 	{
@@ -303,7 +312,7 @@ local testcases = {
 			col = 4,
 			node = "README.md",
 			extension = "md",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_MARKDOWNFILE,
 		},
 	},
 	{
@@ -358,7 +367,7 @@ local testcases = {
 			col = 0,
 			node = "there are spaces.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{
@@ -369,7 +378,7 @@ local testcases = {
 			col = 4,
 			node = "there are spaces.txt",
 			extension = "txt",
-			type = parse.TYPE_FILE,
+			type = parse.TYPE_TXT,
 		},
 	},
 	{


### PR DESCRIPTION
I've added three new file icons, this consists of changes in the parse, config, ui and test files (and obviously the readme). The readme outlines how to go in to the original files and add a new file icon and parser, in the same way that I did locally to add the 3 (pdf, markdown, txt) files I have in this example. There are small changes to specific functions in the parse file like parse_liststyle_3 to add a parameter instead of defining it within the function itself. I have followed the original readme's contribution guidelines. It should be considered to add a config function to add your own icon and parser form the original init.lua config files.