### PR TITLE
nvim 0.13 deprecated BufModifiedSet which breaks the plugin on nightly

### DIFF
--- a/lua/netrw/config.lua
+++ b/lua/netrw/config.lua
@@ -19,8 +19,8 @@ function M.setup(options)
 	M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
 
 	-- Hook on BufModifiedSet to configure the netrw buffer.
-	vim.api.nvim_create_autocmd("BufModifiedSet", {
-		pattern = { "*" },
+	vim.api.nvim_create_autocmd("OptionSet", {
+		pattern = { "modified" },
 		callback = function()
 			if not (vim.bo and vim.bo.filetype == "netrw") then
 				return


### PR DESCRIPTION
I opened nvim today to find errors on my config, turns out they were just that the BufModifiedSet event is gone and we should switch to OptionSet.

I changed it locally and it seems to work perfectly, figured I'd upstream it. I have no idea how to check if someone is running nightly, so I assume for now you won't want to merge this, but I'll look into it and update my fork accordingly hopefully by the end of the week.