### PR TITLE
fix: use FileType autocmd on Neovim 0.11+, fall back to OptionSet on older versions

### DIFF
--- a/lua/netrw/config.lua
+++ b/lua/netrw/config.lua
@@ -18,27 +18,47 @@ M.options = {}
 function M.setup(options)
 	M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
 
-	-- Hook on BufModifiedSet to configure the netrw buffer.
-	vim.api.nvim_create_autocmd("OptionSet", {
-		pattern = { "modified" },
-		callback = function()
-			if not (vim.bo and vim.bo.filetype == "netrw") then
-				return
-			end
+	local function render(bufnr)
+		if
+			vim.b[bufnr].netrw_liststyle ~= 0
+			and vim.b[bufnr].netrw_liststyle ~= 1
+			and vim.b[bufnr].netrw_liststyle ~= 3
+		then
+			return
+		end
 
-			if vim.b.netrw_liststyle ~= 0 and vim.b.netrw_liststyle ~= 1 and vim.b.netrw_liststyle ~= 3 then
-				return
-			end
+		-- Forces the usage of signcolumn in netrw buffers.
+		vim.opt_local.signcolumn = "yes"
 
-			-- Forces the usage of signcolumn in netrw buffers.
-			vim.opt_local.signcolumn = "yes"
+		require("netrw.ui").embelish(bufnr)
+		require("netrw.actions").bind(bufnr)
+	end
 
-			local bufnr = vim.api.nvim_get_current_buf()
-			require("netrw.ui").embelish(bufnr)
-			require("netrw.actions").bind(bufnr)
-		end,
-		group = vim.api.nvim_create_augroup("netrw", { clear = false }),
-	})
+	local group = vim.api.nvim_create_augroup("netrw", { clear = false })
+
+	if vim.version().minor >= 11 then
+		vim.api.nvim_create_autocmd("FileType", {
+			pattern = "netrw",
+			callback = function()
+				local bufnr = vim.api.nvim_get_current_buf()
+				vim.defer_fn(function()
+					render(bufnr)
+				end, 50)
+			end,
+			group = group,
+		})
+	else
+		vim.api.nvim_create_autocmd("OptionSet", {
+			pattern = "modified",
+			callback = function()
+				if not (vim.bo and vim.bo.filetype == "netrw") then
+					return
+				end
+				render(vim.api.nvim_get_current_buf())
+			end,
+			group = group,
+		})
+	end
 end
 
 return M


### PR DESCRIPTION
The behaviour of Neovim 0.11's autocmds was changed, which broke the 'OptionSet' on 'modified' approach used to detect when netrw finishes populating a buffer. This PR adds a version-gated fix: on Neovim 0.11 and above, it uses a 'FileType' autocmd with a short deferral period; older versions continue to use the 'OptionSet' approach.

## Issue with newer versions

Since upgrading to Neovim 0.11, icons and key bindings have stopped appearing in netrw buffers. The 'OptionSet' event on 'modified' no longer reliably fires for netrw buffers in version 0.11 and above.

edit: re-format the description of the PR